### PR TITLE
Fix problematic outputs when no segmentation or no good masks are available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ You have two options to run the *FetMRQC* docker. A wrapper script `run_docker.p
 The `run_docker.py` script automatically handles the mounting of folders onto the docker container, and can help people unfamiliar with docker containers. For those who are familiar with docker, we provide an example of how the inference pipeline can be run by directly calling the docker
 ```
 docker run --rm -it 
-  --gpus all --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
+  --gpus all --gpus all 
+  --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
   -v <your BIDS data folder>:/data/data 
   -v <your masks folder>:/data/masks 
   -v <your output folder>:/data/out 
-  fetmrqc:0.1.0 qc_inference_pipeline 
+  thsanchez/fetmrqc:0.1.2 qc_inference_pipeline 
   --bids_dir /data/data 
   --masks_dir /data/masks 
-  --seg_dir /data/seg 
+  --seg_dir /data/out/seg 
   --bids_csv /data/out/bids_csv.csv 
   --iqms_csv /data/out/iqms_csv.csv 
   --out_csv /data/out/out_csv.csv 

--- a/fetal_brain_qc/metrics/metrics.py
+++ b/fetal_brain_qc/metrics/metrics.py
@@ -709,16 +709,10 @@ class LRStackMetrics:
             if "seg_sstats" in metric:
                 metrics = [f"{n}_{k}" for n in segm_names for k in sstats_keys]
             return {m: np.nan for m in metrics}
+        elif metric == "im_size":
+            return {f"{k}": np.nan for k in ["x", "y", "z"]}
         else:
             return [np.nan]
-
-    def get_default_output(self, metric):
-        """Return the default output for a given metric when the mask is invalid and metrics cannot be computed."""
-        METRIC_DEFAULT = {"cjv": 0}
-        if metric not in METRIC_DEFAULT.keys():
-            return [0.0, False]
-        else:
-            return METRIC_DEFAULT[metric]
 
     def _flatten_dict(self, d):
         """Flatten a nested dictionary by concatenating the keys with '_'."""
@@ -750,9 +744,10 @@ class LRStackMetrics:
                         file=sys.stderr,
                     )
                 out = self.get_nan_output(metric)
+
             # Checking once more that if the metric is nan, we replace it with 0
         else:
-            out = self.get_default_output(metric)
+            out = self.get_nan_output(metric)
         if isinstance(out, dict):
             out = self._flatten_dict(out)
             for k, v in out.items():
@@ -1118,7 +1113,7 @@ class LRStackMetrics:
 
                 assert image.shape == (
                     seg_dict["BG"].shape
-                ), "Image and segmentation have different sizes"
+                ), f"Image and segmentation have different sizes: {image.shape} vs {seg_dict['BG'].shape}"
         if central_third:
             num_z = image.shape[0]
             center_z = int(num_z / 2.0)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def install_requires(fname="requirements.txt"):
 
 setup(
     name="fetal_brain_qc",
-    version="0.1.1",
+    version="0.1.2",
     packages=["fetal_brain_qc"],
     description="Quality control for fetal brain MRI",
     author="Thomas Sanchez",


### PR DESCRIPTION
In cases when no segmentation was computed at all or the mask was not valid, the outputs of the IQMs extraction was not correct.